### PR TITLE
Moving over to using Flask blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,44 +15,44 @@
 
 #### Courses
 ```
-/courses/<term>/<code>
+/v0/courses/<term>/<code>
 ```
 
 #### Classes
 ```
-/class/<class_number>/<term>
+/v0/class/<class_number>/<term>
 ```
 
 #### Lab Status
 ```
-/lab_status/<lab_name>
+/v0/lab_status/<lab_name>
 ```
 
 #### Laundry Status
 For simple laundry status:
 ```
-/laundry/simple/<location>
+/v0/laundry/simple/<location>
 ```
 
 For detailed laundry status:
 ```
-/laundry/detailed/<location>
+/v0/laundry/detailed/<location>
 ```
 
 #### People
 ```
-/people/<query>
+/v0/people/<query>
 ```
 
 #### Shuttles
 For shuttle routes:
 ```
-/shuttle/routes
+/v0/shuttle/routes
 ```
 
 For shuttle vehicle points:
 ```
-/shuttle/points
+/v0/shuttle/points
 ```
 
 For shuttle arrivals:
@@ -68,17 +68,12 @@ For shuttle stop estimates:
 #### Textbooks
 If the term is to be specified:
 ```
-/textbook/<department_code>/<course_name>/<instructor>/<term>
-```
-
-If the term is not to be specified:
-```
-/textbook/<department_code>/<course_name>/<instructor>
+/v0/textbook/<department_code>/<course_name>/<instructor>/<term>
 ```
 
 #### News
 ```
-/news/<feed>/<max_news_items>
+/v0/news/<feed>/<max_news_items>
 ```
 
 

--- a/apiwrapper/__init__.py
+++ b/apiwrapper/__init__.py
@@ -1,17 +1,15 @@
 from flask import Flask
-from flask_restful import Api
 from flask_cors import CORS
 
 cors = CORS()
-restful_api = Api()
+
 
 def create_app():
     app = Flask(__name__)
 
     cors.init_app(app)
-    restful_api.init_app(app)
 
-    from .v0 import rest_api as api_v0
-    app.register_blueprint(api_v0, url_prefix='/v0')
+    from .v0 import restapi_blue
+    app.register_blueprint(restapi_blue)
 
     return app

--- a/apiwrapper/__init__.py
+++ b/apiwrapper/__init__.py
@@ -1,0 +1,17 @@
+from flask import Flask
+from flask_restful import Api
+from flask_cors import CORS
+
+cors = CORS()
+restful_api = Api()
+
+def create_app():
+    app = Flask(__name__)
+
+    cors.init_app(app)
+    restful_api.init_app(app)
+
+    from .v0 import rest_api as api_v0
+    app.register_blueprint(api_v0, url_prefix='/v0')
+
+    return app

--- a/apiwrapper/__init__.py
+++ b/apiwrapper/__init__.py
@@ -1,17 +1,30 @@
+"""
+Web Wrapper for PittAPI, web app for REST endpoints for the PittAPI
+Copyright (C) 2015 Ritwik Gupta
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
 from flask import Flask
 from flask_cors import CORS
 
-from apiwrapper.v0 import restapi_blue
+from apiwrapper.v0 import apiv0_bp
 
 cors = CORS()
 
 
 def create_app():
     app = Flask(__name__)
-
     cors.init_app(app)
-
-    app.register_blueprint(restapi_blue,
-                           url_prefix='/v{version}'.format(
-                               version=0))
+    app.register_blueprint(apiv0_bp, url_prefix='/v0')
     return app

--- a/apiwrapper/__init__.py
+++ b/apiwrapper/__init__.py
@@ -1,6 +1,8 @@
 from flask import Flask
 from flask_cors import CORS
 
+from apiwrapper.v0 import restapi_blue
+
 cors = CORS()
 
 
@@ -9,7 +11,7 @@ def create_app():
 
     cors.init_app(app)
 
-    from .v0 import restapi_blue
-    app.register_blueprint(restapi_blue)
-
+    app.register_blueprint(restapi_blue,
+                           url_prefix='/v{version}'.format(
+                               version=0))
     return app

--- a/apiwrapper/v0/__init__.py
+++ b/apiwrapper/v0/__init__.py
@@ -1,5 +1,26 @@
+"""
+Web Wrapper for PittAPI, web app for REST endpoints for the PittAPI
+Copyright (C) 2015 Ritwik Gupta
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
 from flask import Blueprint
 from flask_restful import Api
 
+from apiwrapper.v0.views import add_resources
+
 restapi_blue = Blueprint('rest_api', __name__)
 rest_api = Api(restapi_blue)
+
+add_resources()

--- a/apiwrapper/v0/__init__.py
+++ b/apiwrapper/v0/__init__.py
@@ -20,7 +20,7 @@ from flask_restful import Api
 
 from apiwrapper.v0.views import add_resources
 
-restapi_blue = Blueprint('rest_api', __name__)
-rest_api = Api(restapi_blue)
+apiv0_bp = Blueprint('rest_api', __name__)
+apiv0 = Api(apiv0_bp)
 
 add_resources()

--- a/apiwrapper/v0/__init__.py
+++ b/apiwrapper/v0/__init__.py
@@ -1,3 +1,5 @@
 from flask import Blueprint
+from flask_restful import Api
 
-rest_api = Blueprint('rest_api', __name__)
+restapi_blue = Blueprint('rest_api', __name__)
+rest_api = Api(restapi_blue)

--- a/apiwrapper/v0/__init__.py
+++ b/apiwrapper/v0/__init__.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+rest_api = Blueprint('rest_api', __name__)

--- a/apiwrapper/v0/views.py
+++ b/apiwrapper/v0/views.py
@@ -1,4 +1,4 @@
-'''
+"""
 Web Wrapper for PittAPI, web app for REST endpoints for the PittAPI
 Copyright (C) 2015 Ritwik Gupta
 
@@ -14,28 +14,18 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-'''
-from flask import  make_response
+"""
+import inspect
+import sys
+
 from flask_restful import Resource
+
 from apiwrapper.PittAPI.PittAPI import course, lab, laundry, people, shuttle, textbook, news
-from apiwrapper.v0 import rest_api
-import json
-
-
-@rest_api.representation('application/json')
-def output_json(data, code, headers=None):
-    """Makes a Flask response with a JSON encoded body"""
-    resp = make_response(json.dumps(data), code)
-    resp.headers.extend(headers or {})
-    return resp
-
-
-@rest_api.errorhandler(404)
-def page_not_found(e):
-    return output_json({'error': 'Invalid request'}, 404)
 
 
 class CourseGetAPI(Resource):
+    PATH = '/courses/<term>/<code>'
+
     def get(self, term, code):
         try:
             return course.get_courses(term, code)
@@ -44,6 +34,8 @@ class CourseGetAPI(Resource):
 
 
 class ClassAPI(Resource):
+    PATH = '/class/<class_number>/<term>'
+
     def get(self, term, class_number):
         try:
             return course.get_class(term, class_number)
@@ -52,6 +44,8 @@ class ClassAPI(Resource):
 
 
 class LabStatusAPI(Resource):
+    PATH = '/lab_status/<lab_name>'
+
     def get(self, lab_name):
         try:
             return lab.get_status(lab_name)
@@ -60,6 +54,8 @@ class LabStatusAPI(Resource):
 
 
 class LaundryStatusAPI(Resource):
+    PATH = '/laundry/simple/<location>'
+
     def get(self, location):
         try:
             return laundry.get_status_simple(location)
@@ -68,6 +64,8 @@ class LaundryStatusAPI(Resource):
 
 
 class LaundryStatusDetailedAPI(Resource):
+    PATH = '/laundry/detailed/<location>'
+
     def get(self, location):
         try:
             return laundry.get_status_detailed(location)
@@ -76,6 +74,8 @@ class LaundryStatusDetailedAPI(Resource):
 
 
 class PeopleAPI(Resource):
+    PATH = '/people/<query>'
+
     def get(self, query):
         try:
             return people.get_person(query)
@@ -84,22 +84,19 @@ class PeopleAPI(Resource):
 
 
 class TextbookAPI(Resource):
+    PATH = '/textbook/<department_code>/<course_name>/<instructor>/<term>'
+
     def get(self, department_code, course_name, instructor, term):
         try:
-            return textbook.get_books_data([{'department_code': department_code, 'course_name': course_name, 'instructor': instructor, 'term': term}])
-        except Exception as e:
-            return {'error': str(e)}
-
-
-class TextbookNoTermAPI(Resource):
-    def get(self, department_code, course_name, instructor, term='2600'):
-        try:
-            return textbook.get_books_data([{'department_code': department_code, 'course_name': course_name, 'instructor': instructor, 'term': term}])
+            return textbook.get_books_data([{'department_code': department_code, 'course_name': course_name,
+                                             'instructor': instructor, 'term': term}])
         except Exception as e:
             return {'error': str(e)}
 
 
 class ShuttleRoutesAPI(Resource):
+    PATH = '/shuttle/routes'
+
     def get(self):
         try:
             return shuttle.get_routes()
@@ -108,6 +105,8 @@ class ShuttleRoutesAPI(Resource):
 
 
 class ShuttleVehiclePointsAPI(Resource):
+    PATH = '/shuttle/points'
+
     def get(self):
         try:
             return shuttle.get_map_vehicle_points()
@@ -116,14 +115,18 @@ class ShuttleVehiclePointsAPI(Resource):
 
 
 class ShuttleStopArrivalsAPI(Resource):
+    PATH = '/shuttle/arrivals/<times_per_stop>'
+
     def get(self, times_per_stop=1):
         try:
-            return shuttle.get_route_stop_arrivals("8882812681",times_per_stop)
+            return shuttle.get_route_stop_arrivals("8882812681", times_per_stop)
         except Exception as e:
             return {'error': str(e)}
 
 
 class ShuttleStopEstimatesAPI(Resource):
+    PATH = '/shuttle/estimates/<vehicle_id>/<quantity>'
+
     def get(self, vehicle_id, quantity=2):
         try:
             return shuttle.get_vehicle_route_stop_estimates(vehicle_id, quantity)
@@ -131,7 +134,9 @@ class ShuttleStopEstimatesAPI(Resource):
             return {'error': str(e)}
 
 
-class NewsAPI(Resource):
+class News(Resource):
+    PATH = '/news/<feed>/<max_news_items>'
+
     def get(self, feed, max_news_items):
         try:
             max_news_items = int(max_news_items)
@@ -140,16 +145,9 @@ class NewsAPI(Resource):
             return {'error': str(e)}
 
 
-rest_api.add_resource(CourseGetAPI, '/courses/<term>/<code>')
-rest_api.add_resource(ClassAPI, '/class/<class_number>/<term>')
-rest_api.add_resource(LabStatusAPI, '/lab_status/<lab_name>')
-rest_api.add_resource(LaundryStatusAPI, '/laundry/simple/<location>')
-rest_api.add_resource(LaundryStatusDetailedAPI, '/laundry/detailed/<location>')
-rest_api.add_resource(PeopleAPI, '/people/<query>')
-rest_api.add_resource(ShuttleRoutesAPI, '/shuttle/routes')
-rest_api.add_resource(ShuttleVehiclePointsAPI, '/shuttle/points')
-rest_api.add_resource(ShuttleStopArrivalsAPI, '/shuttle/arrivals/<times_per_stop>')
-rest_api.add_resource(ShuttleStopEstimatesAPI, '/shuttle/estimates/<vehicle_id>/<quantity>')
-rest_api.add_resource(TextbookAPI, '/textbook/<department_code>/<course_name>/<instructor>/<term>')
-rest_api.add_resource(TextbookNoTermAPI, '/textbook/<department_code>/<course_name>/<instructor>/')
-rest_api.add_resource(NewsAPI, '/news/<feed>/<max_news_items>')
+def add_resources():
+    from apiwrapper.v0 import rest_api
+    clsmembers = inspect.getmembers(sys.modules[__name__], inspect.isclass)
+    clsmembers = [cls[1] for cls in clsmembers if cls[0] != 'Resource']
+    for cls in clsmembers:
+        rest_api.add_resource(cls, cls.PATH)

--- a/apiwrapper/v0/views.py
+++ b/apiwrapper/v0/views.py
@@ -146,8 +146,8 @@ class News(Resource):
 
 
 def add_resources():
-    from apiwrapper.v0 import rest_api
+    from apiwrapper.v0 import apiv0
     clsmembers = inspect.getmembers(sys.modules[__name__], inspect.isclass)
     clsmembers = [cls[1] for cls in clsmembers if cls[0] != 'Resource']
     for cls in clsmembers:
-        rest_api.add_resource(cls, cls.PATH)
+        apiv0.add_resource(cls, cls.PATH)

--- a/apiwrapper/v0/views.py
+++ b/apiwrapper/v0/views.py
@@ -15,17 +15,14 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
-from flask import Flask, make_response
-from flask_restful import Api, Resource
-from flask_cors import CORS, cross_origin
-from .PittAPI.PittAPI import course, lab, laundry, people, shuttle, textbook, news
+from flask import  make_response
+from flask_restful import Resource
+from apiwrapper.PittAPI.PittAPI import course, lab, laundry, people, shuttle, textbook, news
+from apiwrapper.v0 import rest_api
 import json
 
-app = Flask(__name__)
-CORS(app)
-api = Api(app)
 
-@api.representation('application/json')
+@rest_api.representation('application/json')
 def output_json(data, code, headers=None):
     """Makes a Flask response with a JSON encoded body"""
     resp = make_response(json.dumps(data), code)
@@ -33,7 +30,7 @@ def output_json(data, code, headers=None):
     return resp
 
 
-@app.errorhandler(404)
+@rest_api.errorhandler(404)
 def page_not_found(e):
     return output_json({'error': 'Invalid request'}, 404)
 
@@ -85,12 +82,14 @@ class PeopleAPI(Resource):
         except Exception as e:
             return {'error': str(e)}
 
+
 class TextbookAPI(Resource):
     def get(self, department_code, course_name, instructor, term):
         try:
             return textbook.get_books_data([{'department_code': department_code, 'course_name': course_name, 'instructor': instructor, 'term': term}])
         except Exception as e:
             return {'error': str(e)}
+
 
 class TextbookNoTermAPI(Resource):
     def get(self, department_code, course_name, instructor, term='2600'):
@@ -99,12 +98,14 @@ class TextbookNoTermAPI(Resource):
         except Exception as e:
             return {'error': str(e)}
 
+
 class ShuttleRoutesAPI(Resource):
     def get(self):
         try:
             return shuttle.get_routes()
         except Exception as e:
             return {'error': str(e)}
+
 
 class ShuttleVehiclePointsAPI(Resource):
     def get(self):
@@ -113,6 +114,7 @@ class ShuttleVehiclePointsAPI(Resource):
         except Exception as e:
             return {'error': str(e)}
 
+
 class ShuttleStopArrivalsAPI(Resource):
     def get(self, times_per_stop=1):
         try:
@@ -120,12 +122,14 @@ class ShuttleStopArrivalsAPI(Resource):
         except Exception as e:
             return {'error': str(e)}
 
+
 class ShuttleStopEstimatesAPI(Resource):
     def get(self, vehicle_id, quantity=2):
         try:
             return shuttle.get_vehicle_route_stop_estimates(vehicle_id, quantity)
         except Exception as e:
             return {'error': str(e)}
+
 
 class NewsAPI(Resource):
     def get(self, feed, max_news_items):
@@ -136,19 +140,16 @@ class NewsAPI(Resource):
             return {'error': str(e)}
 
 
-api.add_resource(CourseGetAPI, '/courses/<term>/<code>')
-api.add_resource(ClassAPI, '/class/<class_number>/<term>')
-api.add_resource(LabStatusAPI, '/lab_status/<lab_name>')
-api.add_resource(LaundryStatusAPI, '/laundry/simple/<location>')
-api.add_resource(LaundryStatusDetailedAPI, '/laundry/detailed/<location>')
-api.add_resource(PeopleAPI, '/people/<query>')
-api.add_resource(ShuttleRoutesAPI, '/shuttle/routes')
-api.add_resource(ShuttleVehiclePointsAPI, '/shuttle/points')
-api.add_resource(ShuttleStopArrivalsAPI, '/shuttle/arrivals/<times_per_stop>')
-api.add_resource(ShuttleStopEstimatesAPI, '/shuttle/estimates/<vehicle_id>/<quantity>')
-api.add_resource(TextbookAPI, '/textbook/<department_code>/<course_name>/<instructor>/<term>')
-api.add_resource(TextbookNoTermAPI, '/textbook/<department_code>/<course_name>/<instructor>/')
-api.add_resource(NewsAPI, '/news/<feed>/<max_news_items>')
-
-if __name__ is '__main__':
-    app.run(debug=True, port=8000)
+rest_api.add_resource(CourseGetAPI, '/courses/<term>/<code>')
+rest_api.add_resource(ClassAPI, '/class/<class_number>/<term>')
+rest_api.add_resource(LabStatusAPI, '/lab_status/<lab_name>')
+rest_api.add_resource(LaundryStatusAPI, '/laundry/simple/<location>')
+rest_api.add_resource(LaundryStatusDetailedAPI, '/laundry/detailed/<location>')
+rest_api.add_resource(PeopleAPI, '/people/<query>')
+rest_api.add_resource(ShuttleRoutesAPI, '/shuttle/routes')
+rest_api.add_resource(ShuttleVehiclePointsAPI, '/shuttle/points')
+rest_api.add_resource(ShuttleStopArrivalsAPI, '/shuttle/arrivals/<times_per_stop>')
+rest_api.add_resource(ShuttleStopEstimatesAPI, '/shuttle/estimates/<vehicle_id>/<quantity>')
+rest_api.add_resource(TextbookAPI, '/textbook/<department_code>/<course_name>/<instructor>/<term>')
+rest_api.add_resource(TextbookNoTermAPI, '/textbook/<department_code>/<course_name>/<instructor>/')
+rest_api.add_resource(NewsAPI, '/news/<feed>/<max_news_items>')

--- a/apiwrapper/v0/views.py
+++ b/apiwrapper/v0/views.py
@@ -23,7 +23,7 @@ from flask_restful import Resource
 from apiwrapper.PittAPI.PittAPI import course, lab, laundry, people, shuttle, textbook, news
 
 
-class CourseGetAPI(Resource):
+class CourseGet(Resource):
     PATH = '/courses/<term>/<code>'
 
     def get(self, term, code):
@@ -33,7 +33,7 @@ class CourseGetAPI(Resource):
             return {'error': str(e)}
 
 
-class ClassAPI(Resource):
+class Class(Resource):
     PATH = '/class/<class_number>/<term>'
 
     def get(self, term, class_number):
@@ -43,7 +43,7 @@ class ClassAPI(Resource):
             return {'error': str(e)}
 
 
-class LabStatusAPI(Resource):
+class LabStatus(Resource):
     PATH = '/lab_status/<lab_name>'
 
     def get(self, lab_name):
@@ -53,7 +53,7 @@ class LabStatusAPI(Resource):
             return {'error': str(e)}
 
 
-class LaundryStatusAPI(Resource):
+class LaundryStatus(Resource):
     PATH = '/laundry/simple/<location>'
 
     def get(self, location):
@@ -63,7 +63,7 @@ class LaundryStatusAPI(Resource):
             return {'error': str(e)}
 
 
-class LaundryStatusDetailedAPI(Resource):
+class LaundryStatusDetailed(Resource):
     PATH = '/laundry/detailed/<location>'
 
     def get(self, location):
@@ -73,7 +73,7 @@ class LaundryStatusDetailedAPI(Resource):
             return {'error': str(e)}
 
 
-class PeopleAPI(Resource):
+class People(Resource):
     PATH = '/people/<query>'
 
     def get(self, query):
@@ -83,7 +83,7 @@ class PeopleAPI(Resource):
             return {'error': str(e)}
 
 
-class TextbookAPI(Resource):
+class Textbook(Resource):
     PATH = '/textbook/<department_code>/<course_name>/<instructor>/<term>'
 
     def get(self, department_code, course_name, instructor, term):
@@ -94,7 +94,7 @@ class TextbookAPI(Resource):
             return {'error': str(e)}
 
 
-class ShuttleRoutesAPI(Resource):
+class ShuttleRoutes(Resource):
     PATH = '/shuttle/routes'
 
     def get(self):
@@ -104,7 +104,7 @@ class ShuttleRoutesAPI(Resource):
             return {'error': str(e)}
 
 
-class ShuttleVehiclePointsAPI(Resource):
+class ShuttleVehiclePoints(Resource):
     PATH = '/shuttle/points'
 
     def get(self):
@@ -114,7 +114,7 @@ class ShuttleVehiclePointsAPI(Resource):
             return {'error': str(e)}
 
 
-class ShuttleStopArrivalsAPI(Resource):
+class ShuttleStopArrivals(Resource):
     PATH = '/shuttle/arrivals/<times_per_stop>'
 
     def get(self, times_per_stop=1):
@@ -124,7 +124,7 @@ class ShuttleStopArrivalsAPI(Resource):
             return {'error': str(e)}
 
 
-class ShuttleStopEstimatesAPI(Resource):
+class ShuttleStopEstimates(Resource):
     PATH = '/shuttle/estimates/<vehicle_id>/<quantity>'
 
     def get(self, vehicle_id, quantity=2):

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-'''
+"""
 Web Wrapper for PittAPI, web app for REST endpoints for the PittAPI
 Copyright (C) 2015 Ritwik Gupta
 
@@ -14,9 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-'''
+"""
 from apiwrapper import create_app
 
 app = create_app()
-# TODO revert to 0.0.0.0
-app.run(host="127.0.0.1", port=5000, debug=True)
+app.run(host="0.0.0.0", port=5000)

--- a/server.py
+++ b/server.py
@@ -15,6 +15,8 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
-from apiwrapper.views import app
+from apiwrapper import create_app
 
-app.run(host="0.0.0.0", port=5000)
+app = create_app()
+# TODO revert to 0.0.0.0
+app.run(host="127.0.0.1", port=5000)

--- a/server.py
+++ b/server.py
@@ -19,4 +19,4 @@ from apiwrapper import create_app
 
 app = create_app()
 # TODO revert to 0.0.0.0
-app.run(host="127.0.0.1", port=5000)
+app.run(host="127.0.0.1", port=5000, debug=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,16 +18,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import unittest
 
-from apiwrapper.v0.views import app
+from apiwrapper import create_app
 
 
 class APITest(unittest.TestCase):
     def setUp(self):
-        self.app = app.test_client()
+        self.app = create_app().test_client()
         self.app.testing = True
 
     def test_lab_status_cath_g62(self):
-        result = self.app.get("/lab_status/cath_g62")
+        result = self.app.get("/v0/lab_status/cath_g62")
         self.assertEqual(result.status_code, 200)
         self.assertTrue("status" in result.get_data(True))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,8 +16,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
 
-from apiwrapper.views import app
 import unittest
+
+from apiwrapper.v0.views import app
+
 
 class APITest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
So I changed the structure over to using blueprints. The reason for this is they allow scalability and give us a lot of flexibility. We are now able to have separate versions of the API if we decided to change endpoints or add on more APIs.

Other changes include making the app is just a function inside of the `__init__.py`. In `views.py` you can create another endpoint and it will automatically get added to the API's blueprint. All endpoints (or a.k.a. Resources) now need to contain a static variable of their endpoint path.

Also removed one textbook endpoint when no term is entered. Since it requires figuring out what the current term is. 